### PR TITLE
fix horizontal scroll on mobile with overflow: scroll

### DIFF
--- a/index.html
+++ b/index.html
@@ -47,7 +47,6 @@
   </div>
 
   <div class="container mh3 pa4 m-auto">
-
     <!-- Begin MailChimp Signup Form -->
     <h2 class="f-subheadline f3 fw6 mt3">Learn more about staticland & the craft of building static sites</h2>
     <p>We'll send occassional emails about changes to the static.land service, improvements to the underlying open source software, and guides to building static sites.</p>

--- a/index.html
+++ b/index.html
@@ -24,7 +24,7 @@
 
   <div class="container m-auto">
     <h3 class="f-headline f3 f1-ns dark-gray fw3">Static sites with free, automatic SSL for custom domains.</h3>
-    <div class="code ph4 pv2 mv3 bg-black-80 near-white">
+    <div class="code ph4 pv2 mv3 bg-black-80 near-white overflow-scroll">
       <pre>npm install --global staticland</pre>
       <pre>staticland register</pre>
       <pre>staticland site/ yourdomain.com</pre>
@@ -47,7 +47,7 @@
   </div>
 
   <div class="container mh3 pa4 m-auto">
-    
+
     <!-- Begin MailChimp Signup Form -->
     <h2 class="f-subheadline f3 fw6 mt3">Learn more about staticland & the craft of building static sites</h2>
     <p>We'll send occassional emails about changes to the static.land service, improvements to the underlying open source software, and guides to building static sites.</p>
@@ -72,7 +72,7 @@
     <h3 class="f-subheadline f4 fw3 mt3">Create an account:</h3>
 
     <p>
-      <div class="code ph4 pv2 mv3 bg-black-80 near-white">
+      <div class="code ph4 pv2 mv3 bg-black-80 near-white overflow-scroll">
         <pre>staticland register</pre>
       </div>
     </p>
@@ -86,7 +86,7 @@
       Ensure that your domain's DNS settings are pointing at <code>52.39.104.182</code> (or the IP address of your custom server) before deploying:
     </p>
 
-    <div class="code ph4 pv2 mv3 bg-black-80 near-white">
+    <div class="code ph4 pv2 mv3 bg-black-80 near-white overflow-scroll">
       <pre>host static.land</pre>
       <pre>static.land has address 52.39.104.182</pre>
     </div>
@@ -96,7 +96,7 @@
     </p>
 
     <h3 class="f-subheadline f4 fw6 mt5">Deploy a site with auto-SSL:</h3>
-    <div class="code ph4 pv2 mv3 bg-black-80 near-white">
+    <div class="code ph4 pv2 mv3 bg-black-80 near-white overflow-scroll">
       <pre>staticland site/ example.com</pre>
     </div>
   </div>


### PR DESCRIPTION
Hi Seth. Great to see your new product on Hacker News today.

I noticed the horizontal scroll on mobile that is caused by the code examples. This PR fixes this by adding the `overflow-scroll` class to the four examples.

Nice also to see you using @tachyons-css.

Cheers bud