### PR TITLE
Switched a literal ampersand for the HTML entity.

### DIFF
--- a/index.html
+++ b/index.html
@@ -49,7 +49,7 @@
 
   <div class="container mh3 pa4 m-auto">
     <!-- Begin MailChimp Signup Form -->
-    <h2 class="f-subheadline f3 fw6 mt3">Learn more about staticland & the craft of building static sites</h2>
+    <h2 class="f-subheadline f3 fw6 mt3">Learn more about staticland &amp; the craft of building static sites</h2>
     <p>We'll send occassional emails about changes to the static.land service, improvements to the underlying open source software, and guides to building static sites.</p>
     <div id="mc_embed_signup">
     <form action="//land.us9.list-manage.com/subscribe/post?u=4abe8136a2042972c51482cf3&amp;id=9aad36a293" method="post" id="mc-embedded-subscribe-form" name="mc-embedded-subscribe-form" class="validate" target="_blank" novalidate>


### PR DESCRIPTION
The newsletter sign-up form had a literal ampersand, and this was throwing off the Github online editor and VS Code (I imagine others could have been the same) that expected it to open an [HTML entity reference](https://en.wikipedia.org/wiki/List_of_XML_and_HTML_character_entity_references).

I've replaced the literal with the ampersand character entity reference `&amp;`.